### PR TITLE
feat: unit test for aws_lb SG filtering

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws_loadbalancer_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_loadbalancer_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package aws
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
+	"fmt"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
 func TestElbProtocolsAreEqual(t *testing.T) {
@@ -158,4 +161,64 @@ func TestIsNLB(t *testing.T) {
 			t.Errorf("Incorrect value for isNLB() case %s. Got %t, expected %t.", test.name, got, test.want)
 		}
 	}
+}
+
+func TestSecurityGroupFiltering(t *testing.T) {
+	grid := []struct {
+		in          []*ec2.SecurityGroup
+		name        string
+		expected    int
+		description string
+	}{
+		{
+			in: []*ec2.SecurityGroup{
+				&ec2.SecurityGroup{
+					IpPermissions: []*ec2.IpPermission{
+						&ec2.IpPermission{
+							IpRanges: []*ec2.IpRange{
+								&ec2.IpRange{
+									Description: aws.String("an unmanaged"),
+								},
+							},
+						},
+					},
+				},
+			},
+			name:        "unmanaged",
+			expected:    0,
+			description: "An environment without managed LBs should have %d, but found %d SecurityGroups",
+		},
+		{
+			in: []*ec2.SecurityGroup{
+				&ec2.SecurityGroup{
+					IpPermissions: []*ec2.IpPermission{
+						&ec2.IpPermission{
+							IpRanges: []*ec2.IpRange{
+								&ec2.IpRange{
+									Description: aws.String("an unmanaged"),
+								},
+								&ec2.IpRange{
+									Description: aws.String(fmt.Sprintf("%s=%s", NLBClientRuleDescription, "managedlb")),
+								},
+								&ec2.IpRange{
+									Description: aws.String(fmt.Sprintf("%s=%s", NLBHealthCheckRuleDescription, "managedlb")),
+								},
+							},
+						},
+					},
+				},
+			},
+			name:        "managedlb",
+			expected:    1,
+			description: "Found %d, but should have %d Security Groups",
+		},
+	}
+
+	for _, g := range grid {
+		actual := len(filterForIPRangeDescription(g.in, g.name))
+		if actual != g.expected {
+			t.Errorf(g.description, actual, g.expected)
+		}
+	}
+
 }


### PR DESCRIPTION
kubernetes/kubernetes#60825

**What this PR does / why we need it**:
Hey @kellycampbell I saw your awesome PR (kubernetes/kubernetes#68422) and noticed it needed some unit tests. I hope this covers the scope of the problem which you are trying to solve.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60825

**Special notes for your reviewer**:

I ran these on the master branch and noticed that even with 1 Security Group that has an NLBClient Rule and an NLB HealthCheck rule it would duplicate the Security Group in the returned results. Your code does in fact maintain uniqueness in the returned results.

I _think_ the pseudo-code that you drew up references this highlighted zone: https://github.com/kubernetes/kubernetes/blob/a372a9fcd6d749a816b8ce00beed4d00e24b3005/pkg/cloudprovider/providers/aws/aws_loadbalancer.go#L595-L893

There seems to be a ton of duplicated code there for calculating the differences on Security Groups.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
